### PR TITLE
allow Buffer keys to have MDB_INTEGERKEY flag

### DIFF
--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -87,6 +87,7 @@ NAN_METHOD(DbiWrap::ctor) {
         setFlagFromValue(&flags, MDB_INTEGERDUP, "integerDup", false, options);
         setFlagFromValue(&flags, MDB_REVERSEDUP, "reverseDup", false, options);
         setFlagFromValue(&flags, MDB_CREATE, "create", false, options);
+        setFlagFromValue(&flags, MDB_INTEGERKEY, "bufferKeyIsInteger", false, options);
 
         // TODO: wrap mdb_set_compare
         // TODO: wrap mdb_set_dupsort


### PR DESCRIPTION
This allows the user to have integer keys that are 64 bits, as follows:

      // Insert our asins in our bucket, under their bucket.
      const txn = lmdbEnvironment.beginTxn()

      const key = new Buffer(Array(8))
      key.writeUInt32LE(nextBucket, 4)

      let rank = nextBucket * asinsPerBucket
      for (let idx=0, len=asins.length; idx<len; ++idx) {
        console.log('rank', rank+idx, 'asin', asins[idx])
        key.writeUInt32LE(rank+idx, 0)
        const buf = Buffer.from(asins[idx], 'utf8')
        txn.putBinary(rankingDatabase, key, buf)
      }
      
      txn.commit()

These will sort efficiently according to `MDB_INTEGERKEY` rules. Here's how the database is created:

    const rankingDatabase = lmdbEnvironment.openDbi({
      name: database,
      create: true, // will create if this is the first time
      keyIsBuffer: true, // keys are buffers
      bufferKeyIsInteger: true // gives us LE integer ordering
    });
